### PR TITLE
Sprite Flipping On Exit

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Player/Player.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Player.cs
@@ -123,6 +123,8 @@ public class Player : NetworkBehaviour
     private Weapon hitWith;
     private Projectile hitWithProjectile;
 
+    private bool manuallyUpdatedDirection = false;
+
     #endregion
 
     #region Component Variables
@@ -638,6 +640,7 @@ public class Player : NetworkBehaviour
             UpdateSprite();
             return;
         }
+
         //inputs.UpdateInputs();
         OnVelocityChanged(movementState.ApplyFriction(velocity));
         OnExternalForceChanged(movementState.DecayExternalForces(externalForce));
@@ -720,7 +723,12 @@ public class Player : NetworkBehaviour
             return;
         }
 
-        UpdateDirection();
+        if (!manuallyUpdatedDirection)
+        {
+            UpdateDirection();
+        }
+        manuallyUpdatedDirection = false;
+
         UpdateHitbox();
         UpdateSprite();
     }
@@ -738,6 +746,7 @@ public class Player : NetworkBehaviour
 
     public void UpdateDirection(bool right)
     {
+        manuallyUpdatedDirection = true;
         Vector3 localScale = visuals.localScale;
         localScale.x = right ? 1f : -1f;
         visuals.localScale = localScale;

--- a/Unity/Champloo/Assets/Scripts/Player/Player.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Player.cs
@@ -634,6 +634,8 @@ public class Player : NetworkBehaviour
         {
             //controller.Move(velocity * Time.deltaTime);
             UpdateDirection();
+            UpdateHitbox();
+            UpdateSprite();
             return;
         }
         //inputs.UpdateInputs();

--- a/Unity/Champloo/Temp/UnityTempFile-1e3074ed4b4c3e64e86888eeb2ee22ba
+++ b/Unity/Champloo/Temp/UnityTempFile-1e3074ed4b4c3e64e86888eeb2ee22ba
@@ -1,0 +1,122 @@
+-debug
+-target:library
+-nowarn:0169
+-langversion:4
+-out:Temp/Assembly-CSharp-Editor.dll
+-r:"C:/Program Files/Unity/Editor/Data/Managed/UnityEngine.dll"
+-r:"C:/Program Files/Unity/Editor/Data/Managed/UnityEditor.dll"
+-r:Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll
+-r:Library/ScriptAssemblies/Assembly-CSharp.dll
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/Advertisements/Editor/UnityEditor.Advertisements.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/EditorTestsRunner/Editor/nunit.framework.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/EditorTestsRunner/Editor/UnityEditor.EditorTestsRunner.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/GUISystem/UnityEngine.UI.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/GUISystem/Editor/UnityEditor.UI.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/Networking/UnityEngine.Networking.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/Networking/Editor/UnityEditor.Networking.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/PlaymodeTestsRunner/Editor/UnityEditor.PlaymodeTestsRunner.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/PlaymodeTestsRunner/UnityEngine.PlaymodeTestsRunner.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/TreeEditor/Editor/UnityEditor.TreeEditor.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityAnalytics/UnityEngine.Analytics.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityAnalytics/Editor/UnityEditor.Analytics.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityHoloLens/Editor/UnityEditor.HoloLens.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityHoloLens/RuntimeEditor/UnityEngine.HoloLens.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityVR/Editor/UnityEditor.VR.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityVR/RuntimeEditor/UnityEngine.VR.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/NATTraversalForUNET.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/Open.Nat.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/RakNetSwig.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/System.Threading.dll"
+-r:Assets/Rewired/Internal/Libraries/Editor/Rewired_Editor.dll
+-r:Assets/Rewired/Internal/Libraries/Runtime/Rewired_Core.dll
+-r:Assets/Rewired/Internal/Libraries/Runtime/Rewired_Windows_Lib.dll
+-r:"C:/Program Files/Unity/Editor/Data/Managed/UnityEditor.Graphs.dll"
+-r:"C:/Program Files/Unity/Editor/Data/PlaybackEngines/WebGLSupport/UnityEditor.WebGL.Extensions.dll"
+-r:"C:/Program Files/Unity/Editor/Data/PlaybackEngines/LinuxStandaloneSupport/UnityEditor.LinuxStandalone.Extensions.dll"
+-r:"C:/Program Files/Unity/Editor/Data/PlaybackEngines/windowsstandalonesupport/UnityEditor.WindowsStandalone.Extensions.dll"
+-r:"C:/Program Files/Unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/UnityEditor.OSXStandalone.Extensions.dll"
+-r:"C:/Program Files (x86)/Microsoft Visual Studio Tools for Unity/2015/Editor/SyntaxTree.VisualStudio.Unity.Bridge.dll"
+-define:UNITY_5_3_OR_NEWER
+-define:UNITY_5_4_OR_NEWER
+-define:UNITY_5_5_OR_NEWER
+-define:UNITY_5_5_2
+-define:UNITY_5_5
+-define:UNITY_5
+-define:ENABLE_AUDIO
+-define:ENABLE_CACHING
+-define:ENABLE_CLOTH
+-define:ENABLE_DUCK_TYPING
+-define:ENABLE_GENERICS
+-define:ENABLE_MICROPHONE
+-define:ENABLE_MULTIPLE_DISPLAYS
+-define:ENABLE_PHYSICS
+-define:ENABLE_SPRITERENDERER_FLIPPING
+-define:ENABLE_SPRITES
+-define:ENABLE_TERRAIN
+-define:ENABLE_RAKNET
+-define:ENABLE_UNET
+-define:ENABLE_LZMA
+-define:ENABLE_UNITYEVENTS
+-define:ENABLE_WEBCAM
+-define:ENABLE_WWW
+-define:ENABLE_CLOUD_SERVICES_COLLAB
+-define:ENABLE_CLOUD_SERVICES_ADS
+-define:ENABLE_CLOUD_HUB
+-define:ENABLE_CLOUD_PROJECT_ID
+-define:ENABLE_CLOUD_SERVICES_UNET
+-define:ENABLE_CLOUD_SERVICES_BUILD
+-define:ENABLE_CLOUD_LICENSE
+-define:ENABLE_EDITOR_METRICS
+-define:ENABLE_EDITOR_METRICS_CACHING
+-define:INCLUDE_DYNAMIC_GI
+-define:INCLUDE_GI
+-define:PLATFORM_SUPPORTS_MONO
+-define:RENDER_SOFTWARE_CURSOR
+-define:INCLUDE_PUBNUB
+-define:ENABLE_PLAYMODE_TESTS_RUNNER
+-define:ENABLE_SCRIPTING_NEW_CSHARP_COMPILER
+-define:UNITY_STANDALONE_WIN
+-define:UNITY_STANDALONE
+-define:ENABLE_SUBSTANCE
+-define:ENABLE_RUNTIME_GI
+-define:ENABLE_MOVIES
+-define:ENABLE_NETWORK
+-define:ENABLE_CRUNCH_TEXTURE_COMPRESSION
+-define:ENABLE_UNITYWEBREQUEST
+-define:ENABLE_CLOUD_SERVICES
+-define:ENABLE_CLOUD_SERVICES_ANALYTICS
+-define:ENABLE_CLOUD_SERVICES_PURCHASING
+-define:ENABLE_CLOUD_SERVICES_CRASH_REPORTING
+-define:ENABLE_EVENT_QUEUE
+-define:ENABLE_CLUSTERINPUT
+-define:ENABLE_VIDEO
+-define:ENABLE_VR
+-define:ENABLE_WEBSOCKET_HOST
+-define:ENABLE_MONO
+-define:ENABLE_PROFILER
+-define:DEBUG
+-define:TRACE
+-define:UNITY_ASSERTIONS
+-define:UNITY_EDITOR
+-define:UNITY_EDITOR_64
+-define:UNITY_EDITOR_WIN
+-define:UNITY_TEAM_LICENSE
+-define:ENABLE_VSTU
+Assets/ClassTypeReference/Editor/ClassTypeReferencePropertyDrawer.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/Editor/ControlMapperInspector.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/Editor/CustomButtonInspector.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/Editor/CustomSliderInspector.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/Editor/CustomToggleInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/ControllerDataFilesInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/CustomInspector_External.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/HardwareJoystickMapInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/HardwareJoystickTemplateMapInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/InputManagerInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/CustomInspectors/UserDataStore_PlayerPrefsInspector.cs
+Assets/Rewired/Internal/Scripts/Editor/UnityEditorBridge.cs
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\2.0-api\System.Runtime.Serialization.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\2.0-api\System.Xml.Linq.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\2.0-api\UnityScript.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\2.0-api\UnityScript.Lang.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\2.0-api\Boo.Lang.dll"
+-sdk:2.0

--- a/Unity/Champloo/Temp/UnityTempFile-3eea48af9635fa046afad3a4ba2423fe
+++ b/Unity/Champloo/Temp/UnityTempFile-3eea48af9635fa046afad3a4ba2423fe
@@ -1,0 +1,242 @@
+-debug
+-target:library
+-nowarn:0169
+-langversion:4
+-out:Temp/Assembly-CSharp.dll
+-r:"C:/Program Files/Unity/Editor/Data/Managed/UnityEngine.dll"
+-r:Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/GUISystem/UnityEngine.UI.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/Networking/UnityEngine.Networking.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/PlaymodeTestsRunner/UnityEngine.PlaymodeTestsRunner.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityAnalytics/UnityEngine.Analytics.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityHoloLens/RuntimeEditor/UnityEngine.HoloLens.dll"
+-r:"C:/Program Files/Unity/Editor/Data/UnityExtensions/Unity/UnityVR/RuntimeEditor/UnityEngine.VR.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/NATTraversalForUNET.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/Open.Nat.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/RakNetSwig.dll"
+-r:"Assets/Plugins/NAT Traversal for UNET/System.Threading.dll"
+-r:Assets/Rewired/Internal/Libraries/Runtime/Rewired_Core.dll
+-r:Assets/Rewired/Internal/Libraries/Runtime/Rewired_Windows_Lib.dll
+-r:"C:/Program Files/Unity/Editor/Data/Managed/UnityEditor.dll"
+-define:UNITY_5_3_OR_NEWER
+-define:UNITY_5_4_OR_NEWER
+-define:UNITY_5_5_OR_NEWER
+-define:UNITY_5_5_2
+-define:UNITY_5_5
+-define:UNITY_5
+-define:ENABLE_AUDIO
+-define:ENABLE_CACHING
+-define:ENABLE_CLOTH
+-define:ENABLE_DUCK_TYPING
+-define:ENABLE_GENERICS
+-define:ENABLE_MICROPHONE
+-define:ENABLE_MULTIPLE_DISPLAYS
+-define:ENABLE_PHYSICS
+-define:ENABLE_SPRITERENDERER_FLIPPING
+-define:ENABLE_SPRITES
+-define:ENABLE_TERRAIN
+-define:ENABLE_RAKNET
+-define:ENABLE_UNET
+-define:ENABLE_LZMA
+-define:ENABLE_UNITYEVENTS
+-define:ENABLE_WEBCAM
+-define:ENABLE_WWW
+-define:ENABLE_CLOUD_SERVICES_COLLAB
+-define:ENABLE_CLOUD_SERVICES_ADS
+-define:ENABLE_CLOUD_HUB
+-define:ENABLE_CLOUD_PROJECT_ID
+-define:ENABLE_CLOUD_SERVICES_UNET
+-define:ENABLE_CLOUD_SERVICES_BUILD
+-define:ENABLE_CLOUD_LICENSE
+-define:ENABLE_EDITOR_METRICS
+-define:ENABLE_EDITOR_METRICS_CACHING
+-define:INCLUDE_DYNAMIC_GI
+-define:INCLUDE_GI
+-define:PLATFORM_SUPPORTS_MONO
+-define:RENDER_SOFTWARE_CURSOR
+-define:INCLUDE_PUBNUB
+-define:ENABLE_PLAYMODE_TESTS_RUNNER
+-define:ENABLE_SCRIPTING_NEW_CSHARP_COMPILER
+-define:UNITY_STANDALONE_WIN
+-define:UNITY_STANDALONE
+-define:ENABLE_SUBSTANCE
+-define:ENABLE_RUNTIME_GI
+-define:ENABLE_MOVIES
+-define:ENABLE_NETWORK
+-define:ENABLE_CRUNCH_TEXTURE_COMPRESSION
+-define:ENABLE_UNITYWEBREQUEST
+-define:ENABLE_CLOUD_SERVICES
+-define:ENABLE_CLOUD_SERVICES_ANALYTICS
+-define:ENABLE_CLOUD_SERVICES_PURCHASING
+-define:ENABLE_CLOUD_SERVICES_CRASH_REPORTING
+-define:ENABLE_EVENT_QUEUE
+-define:ENABLE_CLUSTERINPUT
+-define:ENABLE_VIDEO
+-define:ENABLE_VR
+-define:ENABLE_WEBSOCKET_HOST
+-define:ENABLE_MONO
+-define:ENABLE_PROFILER
+-define:DEBUG
+-define:TRACE
+-define:UNITY_ASSERTIONS
+-define:UNITY_EDITOR
+-define:UNITY_EDITOR_64
+-define:UNITY_EDITOR_WIN
+-define:UNITY_TEAM_LICENSE
+-define:ENABLE_VSTU
+Assets/ClassTypeReference/ClassTypeConstraintAttribute.cs
+Assets/ClassTypeReference/ClassTypeReference.cs
+"Assets/EZ Camera Shake/Scripts/CameraShakeInstance.cs"
+"Assets/EZ Camera Shake/Scripts/CameraShakePresets.cs"
+"Assets/EZ Camera Shake/Scripts/CameraShaker.cs"
+"Assets/EZ Camera Shake/Scripts/Utilities/CameraUtilities.cs"
+Assets/GamePadInput/Demo/DemoScript.cs
+Assets/GamePadInput/GamePad.cs
+Assets/Lobby/Scripts/DraggablePanel.cs
+Assets/Lobby/Scripts/Lobby/LobbyCountdownPanel.cs
+Assets/Lobby/Scripts/Lobby/LobbyHook.cs
+Assets/Lobby/Scripts/Lobby/LobbyInfoPanel.cs
+Assets/Lobby/Scripts/Lobby/LobbyMainMenu.cs
+Assets/Lobby/Scripts/Lobby/LobbyManager.cs
+Assets/Lobby/Scripts/Lobby/LobbyPlayer.cs
+Assets/Lobby/Scripts/Lobby/LobbyPlayerList.cs
+Assets/Lobby/Scripts/Lobby/LobbyServerEntry.cs
+Assets/Lobby/Scripts/Lobby/LobbyServerList.cs
+Assets/Lobby/Scripts/Lobby/LobbyTopPanel.cs
+"Assets/NAT Traversal Example/ExampleMigrationManager.cs"
+"Assets/NAT Traversal Example/ExampleNetworkManager.cs"
+"Assets/NAT Traversal Example/NATHelperTester.cs"
+"Assets/NAT Traversal Example/NATTraversalExamplePlayer.cs"
+Assets/Rewired/Examples/ControlRemapping1/Scripts/ControlRemappingDemo1.cs
+Assets/Rewired/Examples/CustomControllersTilt/Scripts/CustomControllersTiltDemo.cs
+Assets/Rewired/Examples/CustomControllersTouch/Scripts/CustomControllerDemo.cs
+Assets/Rewired/Examples/CustomControllersTouch/Scripts/CustomControllerDemo_Player.cs
+Assets/Rewired/Examples/CustomControllersTouch/Scripts/TouchButtonExample.cs
+Assets/Rewired/Examples/CustomControllersTouch/Scripts/TouchControllerExample.cs
+Assets/Rewired/Examples/CustomControllersTouch/Scripts/TouchJoystickExample.cs
+Assets/Rewired/Examples/EightPlayers/Scripts/EightPlayersExample_Player.cs
+Assets/Rewired/Examples/FallbackJoystickIdentification/Scripts/FallbackJoystickIdentificationDemo.cs
+Assets/Rewired/Examples/Shared/Scripts/Bullet.cs
+Assets/Rewired/Extras/ControlMapper/Examples/ControlMapperDemo/Scripts/ControlMapperDemoMessage.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ButtonInfo.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CalibrationWindow.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CanvasScalerExt.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CanvasScalerFitter.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ControlMapper.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ControlMapper_Classes.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ControlMapper_Enums.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ControlMapper_InputGrid.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ControlMapper_WindowManager.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CustomButton.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CustomSlider.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/CustomToggle.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ICustomSelectable.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/InputBehaviorWindow.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/InputFieldInfo.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/InputRow.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/LanguageData.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ScrollRectSelectableChild.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ScrollbarVisibilityHelper.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ThemeSettings.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ThemedElement.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/ToggleInfo.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UIControl.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UIControlSet.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UIElementInfo.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UIGroup.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UIImageHelper.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UISelectionUtility.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UISliderControl.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/UITools.cs
+Assets/Rewired/Extras/ControlMapper/Scripts/Window.cs
+Assets/Rewired/Integration/UnityUI/RewiredStandaloneInputModule.cs
+Assets/Rewired/Internal/Scripts/DataStorage/UserDataStore_PlayerPrefs.cs
+Assets/Rewired/Internal/Scripts/InputManager.cs
+Assets/Rewired/Internal/Scripts/Misc/ExternalTools.cs
+Assets/Rewired/Internal/Scripts/Platforms/Ouya/OuyaInputSource.cs
+Assets/Scripts/Audio/PlayRandomSource.cs
+Assets/Scripts/Audio/SceneMusic.cs
+Assets/Scripts/Camera/CameraTarget.cs
+Assets/Scripts/Camera/SmashCamera.cs
+Assets/Scripts/Controllers/CollisionChecker.cs
+Assets/Scripts/Controllers/Controller2D.cs
+Assets/Scripts/Controllers/InputController.cs
+Assets/Scripts/Controllers/PathPlatformController.cs
+Assets/Scripts/Controllers/PlatformController.cs
+Assets/Scripts/Controllers/RaycastController.cs
+Assets/Scripts/DontDestroyOnLoad.cs
+Assets/Scripts/Effects/Blood/BloodSplat.cs
+Assets/Scripts/Effects/Blood/SplatRenderer.cs
+"Assets/Scripts/Effects/Foot Dust/MovementStateFootDust.cs"
+"Assets/Scripts/Game State/Match.cs"
+"Assets/Scripts/Game State/PlayerSettings.cs"
+"Assets/Scripts/Game State/Score.cs"
+"Assets/Scripts/Game State/Timer.cs"
+"Assets/Scripts/Player/Movement States/InAir.cs"
+"Assets/Scripts/Player/Movement States/InAttack.cs"
+"Assets/Scripts/Player/Movement States/InBlock.cs"
+"Assets/Scripts/Player/Movement States/Movement Specials/OnBomb.cs"
+"Assets/Scripts/Player/Movement States/Movement Specials/OnDash.cs"
+"Assets/Scripts/Player/Movement States/Movement Specials/OnRoll.cs"
+"Assets/Scripts/Player/Movement States/Movement Specials/OnSlide.cs"
+"Assets/Scripts/Player/Movement States/Movement Specials/OnTether.cs"
+"Assets/Scripts/Player/Movement States/MovementState.cs"
+"Assets/Scripts/Player/Movement States/OnGround.cs"
+"Assets/Scripts/Player/Movement States/OnMovementSpecial.cs"
+"Assets/Scripts/Player/Movement States/OnWall.cs"
+"Assets/Scripts/Player/Movement States/TauntState.cs"
+Assets/Scripts/Player/Player.cs
+Assets/Scripts/PlayerSpawner.cs
+Assets/Scripts/Spawner.cs
+Assets/Scripts/UI/ActivateChildren.cs
+"Assets/Scripts/UI/Controller Navigation/MultiplayerSelectable.cs"
+"Assets/Scripts/UI/Controller Navigation/MultiplayerUIController.cs"
+"Assets/Scripts/UI/Controller Navigation/MultiplayerUIManager.cs"
+Assets/Scripts/UI/DynamicFont.cs
+Assets/Scripts/UI/ExtraLargeTextSize.cs
+"Assets/Scripts/UI/GIF Encoder/AnimatedGifEncoder.cs"
+"Assets/Scripts/UI/GIF Encoder/CustomEvents.cs"
+"Assets/Scripts/UI/GIF Encoder/GifRecorder.cs"
+"Assets/Scripts/UI/GIF Encoder/LZWEncoder.cs"
+"Assets/Scripts/UI/GIF Encoder/NeuQuant.cs"
+Assets/Scripts/UI/Lobby/ButtonKeyTrigger.cs
+Assets/Scripts/UI/Lobby/LobbyCodeHookTEST.cs
+Assets/Scripts/UI/Lobby/LobbyFlowManager.cs
+Assets/Scripts/UI/Lobby/LobbyManagementHooks.cs
+"Assets/Scripts/UI/Map Select/MapOption.cs"
+"Assets/Scripts/UI/Map Select/MapSelect.cs"
+Assets/Scripts/UI/NetworkLobbyHook.cs
+Assets/Scripts/UI/Networking/DisplayExternalIP.cs
+Assets/Scripts/UI/Networking/GetExternalIP.cs
+"Assets/Scripts/UI/Player Selection/Carousels/Carousel.cs"
+"Assets/Scripts/UI/Player Selection/Carousels/NameCarousel.cs"
+"Assets/Scripts/UI/Player Selection/PlayerSelect.cs"
+"Assets/Scripts/UI/Player Selection/PlayerSelectConfirmation.cs"
+"Assets/Scripts/UI/Player Selection/V2/PlayerOption.cs"
+"Assets/Scripts/UI/Player Selection/V2/PlayerSelectManager.cs"
+Assets/Scripts/UI/PlayerScoreCard.cs
+Assets/Scripts/UI/Scene.cs
+Assets/Scripts/UI/ScoreCardInstantiator.cs
+Assets/Scripts/UI/SettingsHooks/MuteAudio.cs
+Assets/Scripts/UI/TitleGenerator.cs
+"Assets/Scripts/UI/UI Management/Menu.cs"
+"Assets/Scripts/UI/UI Management/MenuManager.cs"
+"Assets/Scripts/UI/UI Management/NetworkedMenuManager.cs"
+Assets/Scripts/UI/UpdatePlayerNumber.cs
+Assets/Scripts/UI/Voting/VotingManager.cs
+Assets/Scripts/Utility/Interpolate.cs
+Assets/Scripts/Utility/TextureScaler.cs
+Assets/Scripts/Utility/TimingState.cs
+Assets/Scripts/Utility/Utility.cs
+Assets/Scripts/Weapons/Projectiles/BombProjectile.cs
+Assets/Scripts/Weapons/Projectiles/Projectile.cs
+Assets/Scripts/Weapons/Projectiles/WineBottleProjectile.cs
+Assets/Scripts/Weapons/Shield.cs
+Assets/Scripts/Weapons/Sword.cs
+Assets/Scripts/Weapons/Weapon.cs
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\unity\System.Runtime.Serialization.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\unity\System.Xml.Linq.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\unity\UnityScript.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\unity\UnityScript.Lang.dll"
+-r:"C:\Program Files\Unity\Editor\Data\MonoBleedingEdge\lib\mono\unity\Boo.Lang.dll"
+-sdk:unity


### PR DESCRIPTION
Sprites were being dumb on exiting wall because both the default update direction and overridden update direction were happening, with the default taking precedent.