### PR TITLE
Fix Sword in Wall

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/Projectile.cs
+++ b/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/Projectile.cs
@@ -25,6 +25,15 @@ public class Projectile : MonoBehaviour
         body = GetComponent<Rigidbody2D>();
     }
 
+    protected virtual void Start()
+    {
+        //check collisions
+        foreach (var col in Physics2D.OverlapBoxAll(transform.position, transform.localScale, transform.rotation.eulerAngles.z, obstacleMask))
+        {
+            OnTriggerEnter2D(col);
+        }
+    }
+
     protected virtual void Update()
     {
         body.velocity = Vector2.zero;

--- a/Unity/Champloo/Assets/Scripts/Weapons/Sword.cs
+++ b/Unity/Champloo/Assets/Scripts/Weapons/Sword.cs
@@ -52,7 +52,7 @@ public class Sword : Weapon {
             Vector2 aim = player.AimDirection;
             Projectile temp = (Projectile)Instantiate(
                 thrownVersion,
-                transform.position,
+                player.transform.position,
                 Quaternion.AngleAxis(
                     Utility.Vector2AsAngle(aim),//input.leftStickAngle,//transform.parent.parent.localScale.x < 0 ? 180 - input.leftStickAngle : input.leftStickAngle,
                     transform.parent.forward


### PR DESCRIPTION
Handle on-spawn collisions and centering the projectile on the player instead of the sword