### PR TITLE
Fix Input window giving false positives

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Controllers/InputController.cs
+++ b/Unity/Champloo/Assets/Scripts/Controllers/InputController.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 using GamepadInput;
 using Rewired;
 
 public class InputController : MonoBehaviour
 {
+    private Rewired.Player inputPlayer;
+
     [SerializeField]
     private float angleDeadzone;
 
@@ -17,10 +20,28 @@ public class InputController : MonoBehaviour
     private float xAngleDeadZone;
     private float yAngleDeadZone;
 
+    private Dictionary<String, bool> consumedActions;
+
     private void Start()
     {
         xAngleDeadZone = Mathf.Sin(angleDeadzone * Mathf.Deg2Rad);
         yAngleDeadZone = Mathf.Cos(angleDeadzone * Mathf.Deg2Rad);
+
+        consumedActions = new Dictionary<string, bool>();
+
+        inputPlayer = GetComponentInParent<Player>().InputPlayer;
+    }
+
+    private void LateUpdate()
+    {
+        //unconsume non-pressed buttons
+        foreach (KeyValuePair<string, bool> pair in consumedActions)
+        {
+            if (!inputPlayer.GetButton(pair.Key))
+            {
+                consumedActions[pair.Key] = false;
+            }
+        }
     }
 
     public Vector2 ApplyDeadZone(Vector2 input)
@@ -35,5 +56,18 @@ public class InputController : MonoBehaviour
     {
         if (Mathf.Abs(axis) < xAngleDeadZone) return 0f;
         return axis;
+    }
+
+    public bool IsConsumed(String actionName)
+    {
+        return consumedActions.ContainsKey(actionName) && consumedActions[actionName];
+    }
+
+    public void ConsumeButton(String actionName)
+    {
+        if (inputPlayer.GetButton(actionName))
+        {
+            consumedActions[actionName] = true;
+        }
     }
 }

--- a/Unity/Champloo/Assets/Scripts/Player/Movement States/OnGround.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Movement States/OnGround.cs
@@ -55,9 +55,10 @@ public class OnGround : MovementState
         base.ApplyInputs(inVelocity, inExternalForces, out outVelocity, out outExternalForces);
 
         Jumped = false;
-        if (input.GetButtonDown("Jump"))
+        if (input.GetButtonDown("Jump") && !inputController.IsConsumed("Jump"))
         {
             Jumped = true;
+            inputController.ConsumeButton("Jump");
             player.FireEvent(new JumpEvent {Active = this, Direction = Vector3.up});
             outVelocity.y = jumpVelocity;
         }

--- a/Unity/Champloo/Assets/Scripts/Player/Movement States/OnWall.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Movement States/OnWall.cs
@@ -72,9 +72,10 @@ public class OnWall : MovementState
         int wallDirX = (controller.collisions.Left) ? -1 : 1;
 
         jumped = false;
-        if (player.InputPlayer.GetButtonDown("Jump"))
+        if (player.InputPlayer.GetButtonDown("Jump") && !inputController.IsConsumed("Jump"))
         {
             jumped = true;
+            inputController.ConsumeButton("Jump");
 
             //PLayer will always jump off of a wall a little bit
             outVelocity.x = (wallJumpVelocity.x / 2) * (-wallDirX);


### PR DESCRIPTION
We now consume jumps instead of letting them linger. Rewired says that
this logic is an implication of bad code, but I can't think of another
way around it.