### PR TITLE
Allow swords to be picked up when camped

### DIFF
--- a/Unity/Champloo/Assets/Resources/Prefabs/Weapon/Sword Projectile.prefab
+++ b/Unity/Champloo/Assets/Resources/Prefabs/Weapon/Sword Projectile.prefab
@@ -258,6 +258,8 @@ MonoBehaviour:
   minVelocity: 16
   maxVelocity: 25
   velocityAnimationTime: 0.2
+  maxColliderSize: {x: 2, y: 2}
+  growthTime: 5
 --- !u!212 &212003549059143196
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/ThrownSwordProjectile.cs
+++ b/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/ThrownSwordProjectile.cs
@@ -3,6 +3,32 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class ThrownSwordProjectile : Projectile {
+    [SerializeField]
+    private Vector2 maxColliderSize;
+
+    [SerializeField]
+    private float growthTime = 10f;
+
+    private Vector2 startColliderSize;
+    private bool growing = false;
+    private float startGrowTime;
+
+    protected override void Update()
+    {
+        base.Update();
+
+        if (!Moving)
+        {
+            if (!growing)
+            {
+                growing = true;
+                startGrowTime = Time.time;
+            }
+            Vector3 size = Vector2.Lerp(startColliderSize, maxColliderSize, (Time.time - startGrowTime) / growthTime);
+            ((BoxCollider2D) hitbox).size = size;
+        }
+    }
+
     protected override void ProcessHitPlayer(GameObject g)
     {
         Player p = g.GetComponent<Player>()


### PR DESCRIPTION
Decided to have the swords "expand" their range over time, up to a max
range. Now players can pick up swords without having to be as close to
them as before.

We need to telegraph picking up more effectively than we currently do in
order for this to be intuitive, but it should be fine overall.