### PR TITLE
Lances now end out correctly

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/Lance.cs
+++ b/Unity/Champloo/Assets/Scripts/Weapons/Projectiles/Lance.cs
@@ -49,7 +49,7 @@ public class Lance : Projectile {
 
     void Finish()
     {
-        moving = false;
-        OurPlayer.GetHit(this);
+        OurPlayer.GetComponentInChildren<Weapon>().PickUp();
+        Destroy(gameObject);
     }
 }


### PR DESCRIPTION
Used to go through hitting the player and THEN being picked up. Can
introduce a race condition if an unarmed player interacts with the sword
same frame, possibly. Better safe than sorry.