### PR TITLE
Cancel any other spawn invokations

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Player/Player.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Player.cs
@@ -238,6 +238,7 @@ public class Player : NetworkBehaviour
 
     private void Spawn()
     {
+        CancelInvoke("Spawn");
         transform.position = FindObjectOfType<PlayerSpawner>().FindValidSpawn(this);
         gameObject.SetActive(true);
         OnDeathChanged(false);


### PR DESCRIPTION
This may still double spawn if the invoked spawn somehow beats the Start
spawn. I get the feeling that it is impossible for that to happen
though, based on how Unity's order of events works.