### PR TITLE
On roll in air

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Player/Movement States/Movement Specials/OnRoll.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Movement States/Movement Specials/OnRoll.cs
@@ -21,6 +21,11 @@ public class OnRoll : OnMovementSpecial
     private bool goingRight = true;
     private bool canAirRoll = true;
 
+    public override bool canUse
+    {
+        get { return base.canUse && (!(GetSimulatedState() is InAir) || canAirRoll); }
+    }
+
 
     public override Vector3 ApplyFriction(Vector3 velocity)
     {

--- a/Unity/Champloo/Assets/Scripts/Player/Movement States/OnMovementSpecial.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Movement States/OnMovementSpecial.cs
@@ -20,9 +20,9 @@ public class OnMovementSpecial : MovementState
     protected float cooldownTimeLeft;
 
     //bools for determining current state
-    public bool canUse { get { return !isDisabled && timingState == TimingState.DONE; } }
-    public bool isInUse { get { return timingState == TimingState.IN_PROGRESS; } }
-    public bool isDisabled { get; set; }
+    public virtual bool canUse { get { return !isDisabled && timingState == TimingState.DONE; } }
+    public virtual bool isInUse { get { return timingState == TimingState.IN_PROGRESS; } }
+    public virtual bool isDisabled { get; set; }
 
     //Used On the start of the player object
     protected override void Start()

--- a/Unity/Champloo/Assets/Scripts/Player/Player.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Player.cs
@@ -728,7 +728,7 @@ public class Player : NetworkBehaviour
         //else if(inputs.movementSpecial.Down && !(movementState is OnDash) && currentDashes > 0)
         else if(InputPlayer.GetButtonDown("Movement Special")
             && !(InputPlayer.GetButtonDown("Attack") || InputPlayer.GetButtonDown("Weapon Special"))
-            && !(movementState is OnMovementSpecial) && !movementSpecial.isDisabled)
+            && !(movementState is OnMovementSpecial) && !movementSpecial.isDisabled && movementSpecial.canUse)
         {
             next = GetComponentInChildren<OnMovementSpecial>();
         }


### PR DESCRIPTION
OnRoll shouldn't be able to entered twice while in air. We were shorting out, instead of preventing entering altogether.