### PR TITLE
Readd blocking bounce

### DIFF
--- a/Unity/Champloo/Assets/Scripts/Player/Movement States/InBlock.cs
+++ b/Unity/Champloo/Assets/Scripts/Player/Movement States/InBlock.cs
@@ -27,7 +27,8 @@ public class InBlock : MovementState
     public override Vector3 ApplyFriction(Vector3 velocity)
     {
         float newVelocityX = Mathf.MoveTowards(velocity.x, 0f, deceleration*Time.deltaTime);
-        velocity.x = Mathf.Abs(prevVelocity.x) < Mathf.Abs(newVelocityX) ? prevVelocity.x : newVelocityX;
+        //velocity.x = Mathf.Abs(prevVelocity.x) < Mathf.Abs(newVelocityX) ? prevVelocity.x : newVelocityX;
+        velocity.x = newVelocityX;
 
         if (controller.collisions.Above && velocity.y > 0) velocity.y = 0;
 


### PR DESCRIPTION
Now the blocking velocity can increase again like before. We should just
make the deceleration higher instead of what we were doing before.