### PR TITLE
Fix menu flashing when non-entered player leaves

### DIFF
--- a/Unity/Champloo/Assets/Scripts/UI/Controller Navigation/MultiplayerUIManager.cs
+++ b/Unity/Champloo/Assets/Scripts/UI/Controller Navigation/MultiplayerUIManager.cs
@@ -128,7 +128,7 @@ public class MultiplayerUIManager : MonoBehaviour
         bool playerLeftOrJoined = false;
         foreach (var player in ReInput.players.Players)
 	    {
-	        if (playersCanJoin && player.GetAnyButtonDown() && !ContainsController(player))
+	        if (playersCanJoin && player.GetAnyButtonDown() && !player.GetButtonDown(leaveAction) && !ContainsController(player))
 	        {
 	            //player has joined
                 AddController(player);


### PR DESCRIPTION
Players would be added and then immediately removed whenever they hit
"leave", since joining listened to the leave button as well :P